### PR TITLE
add new xeno fswatch command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ language: shell
 
 # Install build dependencies
 install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update
   - sudo apt-get -qq install git devscripts shunit2 openssh-client openssh-server
+  - sudo apt-get -qq install g++-4.8
+  - export CXX="g++-4.8" CC="gcc-4.8"
+  - sudo -E scripts/ci-install-fswatch.sh
 
 # Setup SSH infrastructure necessary to run tests
 before_script:
@@ -17,6 +21,7 @@ script:
   - shunit2 scripts/ci-test-xeno.sh
   - shunit2 scripts/ci-test-xeno-config.sh
   - shunit2 scripts/ci-test-xeno-daemon.sh
+  - shunit2 scripts/ci-test-xeno-fswatch.sh
   - shunit2 scripts/ci-test-xeno-editing.sh
 
 # Send notifications

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ xeno supports the following subcommands:
   configuration information
 - [__daemon__](https://github.com/havoc-io/xeno/wiki/sync): Starts and stops the
   xeno daemon
+- [__fswatch__](https://github.com/havoc-io/xeno/wiki/fswatch): Starts and stops
+  the xeno fswatch daemon
 
 To keep consistency, if you use the `xeno edit` command on a local path outside
 of an SSH session, it will simply open the local path in your editor.  Thus, it
@@ -79,12 +81,18 @@ xeno has a *very* minimal set of system dependencies, in particular:
 - OpenSSH
 - OpenSSL
 - Git 1.7.6+
+- fswatch (optional)
 
 Most systems meet the POSIX, OpenSSH, and OpenSSL requirements out of the box,
 and Git is generally going to be installed on most systems of interest.  These
 requirements apply to both ends of the editing connection, though on the client
 side only OpenSSH client is required, and on the server side only OpenSSH server
 is required.
+
+`fswatch` is multi-platform file-change notification utility. It is designed to
+work on Mac OSX, Linux, *BSD using whatever file-change notification facility
+is available on each particular platform. It's use is optional and only required
+if the `xeno fswatch` daemon mode is used.
 
 If there are issues, please let me know.  I'd like to make things work on as
 many systems and shells as possible (within reason).
@@ -98,7 +106,7 @@ that you set up SSH connection multiplexing.  This allows you to persist SSH
 connections and re-use them, and will make SSH, Git, and xeno much faster for
 you.  Instead of trying to give instructions here, I'll point you to this
 [awesome article by Rackspace](developer.rackspace.com/blog/speeding-up-ssh-session-creation.html)
-which gives an overview of the process. 
+which gives an overview of the process.
 
 The xeno program is a portable shell script, so you can simply download it from
 [here](https://raw.githubusercontent.com/havoc-io/xeno/1.0.5/xeno) and put
@@ -164,6 +172,18 @@ xeno supports the following configuration keys:
   when pushing local changes.  If this is set to "true", xeno will check the
   remote for changes every time it checks the local copy.
 
+fswatch daemon mode
+-------------------
+
+In order to speed up the pushing of changes to remote server you may use the
+`xeno fswatch` daemon mode. When running in this mode, fswatch is used to detect
+changes to local content and then immediately trigger `xeno sync` to sync those
+changes to the remote host.
+
+`xeno fswatch` may be used in conjunction with `xeno daemon` because remote
+changes will not be picked up by fswatch. Thus, it may be necessary to also run
+`xeno daemon` to periodically pull remote changes into the local copy (the
+`sync.force` config option must be set).
 
 Implementation
 --------------
@@ -181,7 +201,7 @@ remote machine to track and coordinate changes.  It installs some hooks in the
 remote repository to do some comitting/merging on the remote end every time a
 push is received from the local end.  xeno will then clone the remote
 repository and launch your local editor on the clone.  The basic repository
-synchronization flow looks like:   
+synchronization flow looks like:
 
     ------------------------------------------------------------------------
     |                                                               Editor |

--- a/scripts/ci-install-fswatch.sh
+++ b/scripts/ci-install-fswatch.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+fswatch_version="1.4.6"
+
+wget https://github.com/emcrisostomo/fswatch/releases/download/${fswatch_version}/fswatch-${fswatch_version}.tar.gz
+tar xzf fswatch-${fswatch_version}.tar.gz
+cd fswatch-${fswatch_version}
+./configure
+make
+make install

--- a/scripts/ci-test-xeno-fswatch.sh
+++ b/scripts/ci-test-xeno-fswatch.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+
+# Tests the 'xeno fswatch' command
+
+# @TODO(joe): a real integration test which runs fswatch and tests change detection.
+
+testExitCodes()
+{
+  # Check that running with a short help flag results in a non-error exit code
+  xeno fswatch -h > /dev/null 2>&1
+  result=$?
+  assertEquals "xeno fswatch with -h should exit with code 0" 0 ${result}
+
+  # Check that running with a long help flag results in a non-error exit code
+  xeno fswatch --help > /dev/null 2>&1
+  result=$?
+  assertEquals "xeno fswatch with --help should exit with code 0" 0 ${result}
+
+
+  # Check that running with a short stop flag results in a non-error exit code
+  xeno fswatch -s > /dev/null 2>&1
+  result=$?
+  assertEquals "xeno fswatch with -s should exit with code 0" 0 ${result}
+
+  # Check that running with a long stop flag results in a non-error exit code
+  xeno fswatch --stop > /dev/null 2>&1
+  result=$?
+  assertEquals "xeno fswatch with --stop should exit with code 0" 0 ${result}
+}
+
+
+testStartStop()
+{
+  # Kill any existing instances
+  xeno fswatch --stop
+
+  # Start an instance
+  xeno fswatch
+  result=$?
+  assertEquals "xeno fswatch should start successfully" 0 ${result}
+
+  # Make sure it started
+  result=$(ps -U $(id -u) -o pid -o args \
+           | grep 'xeno-fswatch-run' \
+           | grep -v 'grep' \
+           | wc -l)
+  assertEquals "xeno fswatch should be running" "1" ${result}
+
+  # Stop it
+  xeno fswatch --stop
+  result=$?
+  assertEquals "xeno fswatch should stop successfully" 0 ${result}
+
+  # Make sure it stopped
+  result=$(ps -U $(id -u) -o pid -o args \
+           | grep 'xeno-fswatch-run' \
+           | grep -v 'grep' \
+           | wc -l)
+  assertEquals "xeno fswatch should not be running" "0" ${result}
+}

--- a/xeno
+++ b/xeno
@@ -39,7 +39,7 @@ fi
 
 
 # Version constants
-XENO_VERSION="1.0.5"
+XENO_VERSION="1.0.6"
 
 
 # Help constants
@@ -57,6 +57,7 @@ The most commonly used subcommands are:
   ssh                   start a xeno-aware SSH session
   config                edit xeno configuration
   daemon                start the xeno daemon
+  fswatch               start the fswatch daemon
 
 To see help information for a subcommand, use 'xeno <subcommand> --help'
 "
@@ -145,6 +146,14 @@ optional arguments:
   -s, --stop            stop the existing daemon, if any
 "
 
+USAGE_FSWATCH="usage: xeno fswatch [-h|--help] [-s|--stop]
+
+launch the xeno fswatch daemon (no-op if fswatch is already running)
+
+optional arguments:
+  -h, --help            show this message and exit
+  -s, --stop            stop the existing daemon, if any
+"
 
 # xeno variables, some of which are overridable
 XENO_PATH="$0"
@@ -303,6 +312,12 @@ random_id () {
   # versions spit out
   head -c 1024 /dev/urandom | openssl dgst -sha1 | sed 's/^.* //'
 }
+
+
+# Function to test a string begins with substr, eg:
+#   beginswith foo foobar  # true
+#   beginswith bar foobar  # false
+beginswith() { case $2 in $1*) true;; *) false;; esac; }
 
 
 # Acquire a xeno lock
@@ -1298,6 +1313,140 @@ xeno_daemon () {
   finish
 }
 
+# 'fswatch' subcommand handler
+xeno_fswatch () {
+  # Parse arguments
+  mode="launch"
+  while [ $# -gt 0 ]; do
+    # Grab the argument
+    arg="$1"
+    # Gobble up this argument
+    shift
+    # Check the argument value
+    case "$arg" in
+      -h)
+        echo "$USAGE_FSWATCH"
+        finish
+        ;;
+      --help)
+        echo "$USAGE_FSWATCH"
+        finish
+        ;;
+      -s)
+        mode="stop" ;;
+      --stop)
+        mode="stop" ;;
+      --xeno-fswatch-run)
+        mode="run" ;;
+      *)
+        echo "error: invalid argument: $arg"
+        echo "$USAGE_FSWATCH"
+        die
+        ;;
+    esac
+  done
+
+  # Switch based on mode
+  if [ "$mode" = "launch" ]; then
+    # ensure `fswatch` is installed
+    if ! `command -pv fswatch >/dev/null 2>&1`; then
+      echo "fswatch is not installed or is not in the current PATH."
+      die
+    fi
+
+    # Launch a new xeno fswatch if there is none already running
+    running=$(ps -U $(id -u) -o pid -o args \
+              | grep 'xeno-fswatch-run' \
+              | grep -v 'grep')
+    if [ -z "$running" ]; then
+      # Launch the daemon in the background, using 0<&- to close stdin, and
+      # sending the output to a log file
+      log_file="$XENO_WORKING_DIRECTORY/fswatch.log"
+      xeno fswatch --xeno-fswatch-run 0<&- > "$log_file" 2>&1 &
+    fi
+  elif [ "$mode" = "run" ]; then
+    # Release our lock, we won't need it, since we delegate to 'xeno sync'
+    unlock_xeno
+
+    # Compute sync arguments
+    poll_remote=$(read_config sync.force)
+    if [ "$poll_remote" = "true" ]; then
+      sync_arguments="--force"
+    fi
+
+    echo "$(date): xeno fswatch started"
+
+    # @TODO(joe): optimize by using the fswatch batch-marker and ensuring we
+    #             only call sync once per session for the case when many files
+    #             may be updated at nearly the same time (within 1 second which
+    #             is our `-l` arg to fswatch)
+
+    # main loop:
+    # spawn `fswatch` to watch or changes across all local xeno git directories.
+    # fswatch will print the full path of each file that is changed, which we
+    # match against a list of known sessions and then call
+    # `xeno sync <SESSION_ID>` to sync it to the remote.
+    #
+    # We exclude '.git' directories since those are updated by xeno sync. If
+    # they are not excluded, the first time a file is changed it will put us
+    # into a loop of infinite sync'ing.
+    fswatch -r --exclude='^.*\/.git\/' -l 1 "$XENO_LOCAL_SESSION_DIRECTORY" \
+      | while read -r line; do
+          # echo "$line"
+          found=0
+          session_index=1
+          for s in $(list_sessions); do
+            if beginswith "$XENO_LOCAL_SESSION_DIRECTORY/$s" "$line"; then
+              echo "$line matches session $session_index, calling xeno sync"
+              found=1
+              xeno sync $session_index "$sync_arguments"
+              break
+            fi
+            session_index=$((session_index + 1))
+          done
+          if [ "$found" = "0" ]; then
+            echo "could not find a matching session."
+          fi
+        done
+
+    echo "$(date): xeno fswatch exiting"
+  elif [ "$mode" = "stop" ]; then
+    # Release our lock so that if, for some reason, the daemon is still trying
+    # to acquire its initial lock, we don't deadlock waiting for it to exit
+    unlock_xeno
+
+    # Loop while the fswatch daemon may be alive
+    while :
+    do
+      running=$(ps -U $(id -u) -o pid -o args \
+                | grep 'xeno-fswatch-run' \
+                | grep -v 'grep' \
+                | head -n 1 \
+                | sed 's/^[ \t]*//' \
+                | cut -d ' ' -f1)
+
+      # If we find an existing session...
+      if [ ! -z "$running" ]; then
+        # Send it a termination signal using pkill -P to ensure the fswatch
+        # child is killed as well. This should work across at least linux and
+        # osx (tested on osx).
+        pkill -P "$running"
+
+        # Wait and then check again
+        sleep 1
+      else
+        # Nothing was there, so we're done
+        break
+      fi
+    done
+
+    # Exit manually since we don't have a lock
+    exit 0
+  fi
+
+  finish
+}
+
 
 # Run the appropriate subcommand
 case "$#" in
@@ -1328,6 +1477,8 @@ case "$#" in
         xeno_config "$@" ;;
       daemon)
         xeno_daemon "$@" ;;
+      fswatch)
+        xeno_fswatch "$@" ;;
       -v)
         echo "$XENO_VERSION"
         finish


### PR DESCRIPTION
This PR implements a new `xeno fswatch` command which uses the `fswatch` file-change notification utility to optimize (ie: near realtime) local change detection and initiating syncs to the remote hosts.

https://github.com/emcrisostomo/fswatch

I wanted a way to more quickly sync changes from my local workstation to remote machines. The best I had come up with was to run `xeno daemon` with a low (3-5 second) interval time, but this is not optimal when you have several repos and generates a lot of traffic and log messages due to the frequent ssh'ing. I wanted something faster to get close as possible to near-realtime detection of changes and sync'ing to the remote host. `fswatch` which is cross platform (osx, linux, *bsd) seemed like a perfect fit.

Usage is very similar to `xeno daemon`:  `xeno fswatch` to start the xeno-fswatch daemon and `xeno fswatch --stop` to stop it. When a change is detected in any of the repos in `$HOME/.xeno/local/*` a corresponding `xeno sync SESSION_ID` will be triggered.

I still use `xeno daemon` to periodically pull in remote changes but I now use it with a much longer interval (120 seconds or more) and rely on `xeno fswatch` to handle most sync'ing.

I considered implementing this within the `xeno daemon` command and that may still be the best place for this, but keeping it separate made initial implementation and testing easier.

Any thoughts on accepting this into xeno mainline? I'd be willing to try to adapt it to fit the overall vision of xeno. Let me know.